### PR TITLE
Add per-transaction withdrawal limit to vault state

### DIFF
--- a/programs/lamports-vault/src/error.rs
+++ b/programs/lamports-vault/src/error.rs
@@ -4,4 +4,6 @@ use anchor_lang::prelude::*;
 pub enum ErrorCode {
     #[msg("Custom error message")]
     CustomError,
+    #[msg("Withdrawal amount exceeds the per-transaction limit")]
+    ExceedsMaxWithdraw,
 }

--- a/programs/lamports-vault/src/instructions/initialize.rs
+++ b/programs/lamports-vault/src/instructions/initialize.rs
@@ -23,7 +23,7 @@ pub struct Initialize<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn initialize_vault(ctx: Context<Initialize>) -> Result<()> {
+pub fn initialize_vault(ctx: Context<Initialize>, max_withdraw: u64) -> Result<()> {
     msg!("Initializing vault for user: {}", ctx.accounts.user.key());
 
     let cpi_acccounts = anchor_lang::system_program::Transfer {
@@ -39,7 +39,8 @@ pub fn initialize_vault(ctx: Context<Initialize>) -> Result<()> {
 
     ctx.accounts.vault_state.set_inner(VaultState {
         vault_bump: ctx.bumps.vault, 
-        bump: ctx.bumps.vault_state
+        bump: ctx.bumps.vault_state,
+        max_withdraw,
     });
     
     Ok(())

--- a/programs/lamports-vault/src/instructions/withdraw.rs
+++ b/programs/lamports-vault/src/instructions/withdraw.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::{VAULT_SEED, VAULT_STATE_SEED, VaultState};
+use crate::{error::ErrorCode, VAULT_SEED, VAULT_STATE_SEED, VaultState};
 
 #[derive(Accounts)]
 pub struct Withdraw<'info> {
@@ -22,6 +22,11 @@ pub struct Withdraw<'info> {
 }
 
 pub fn withdraw_lamports(ctx: Context<Withdraw>, amount: u64) -> Result<()> {
+    require!(
+        amount <= ctx.accounts.vault_state.max_withdraw,
+        ErrorCode::ExceedsMaxWithdraw
+    );
+
     msg!("Withdrawing lamports from vault");
     let cpi_accounts = anchor_lang::system_program::Transfer {
         from: ctx.accounts.vault.to_account_info(),

--- a/programs/lamports-vault/src/lib.rs
+++ b/programs/lamports-vault/src/lib.rs
@@ -15,8 +15,8 @@ declare_id!("9AvGuh5C8cYcYU7RwwWQU9iDFqWpjQ9MnGZ8cfbkJPLc");
 pub mod lamports_vault {
     use super::*;
 
-    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
-        initialize::initialize_vault(ctx)
+    pub fn initialize(ctx: Context<Initialize>, max_withdraw: u64) -> Result<()> {
+        initialize::initialize_vault(ctx, max_withdraw)
     }
 
     pub fn deposit(ctx: Context<Deposit>, amount: u64) -> Result<()> {

--- a/programs/lamports-vault/src/state/vault_state.rs
+++ b/programs/lamports-vault/src/state/vault_state.rs
@@ -5,4 +5,5 @@ use anchor_lang::prelude::*;
 pub struct VaultState {
     pub vault_bump: u8,     // The bump seed for the vault account PDA
     pub bump: u8,           // The bump seed for the VaultState PDA itself
+    pub max_withdraw: u64,  // Per-transaction withdrawal cap, in lamports
 }

--- a/programs/lamports-vault/tests/common/mod.rs
+++ b/programs/lamports-vault/tests/common/mod.rs
@@ -40,13 +40,13 @@ pub fn vault_pda(user: &Pubkey) -> (Pubkey, u8) {
     Pubkey::find_program_address(&[VAULT_SEED, user.as_ref()], &lamports_vault::id())
 }
 
-pub fn build_initialize_ix(payer: &Pubkey) -> Instruction {
+pub fn build_initialize_ix(payer: &Pubkey, max_withdraw: u64) -> Instruction {
     let (vault_state, _) = vault_state_pda(payer);
     let (vault, _) = vault_pda(payer);
 
     Instruction::new_with_bytes(
         lamports_vault::id(),
-        &lamports_vault::instruction::Initialize {}.data(),
+        &lamports_vault::instruction::Initialize { max_withdraw }.data(),
         lamports_vault::accounts::Initialize {
             user: *payer,
             vault_state,
@@ -108,7 +108,7 @@ pub fn send(
     svm.send_transaction(tx)
 }
 
-pub fn initialize_vault(svm: &mut LiteSVM, payer: &Keypair) {
-    let ix = build_initialize_ix(&payer.pubkey());
+pub fn initialize_vault(svm: &mut LiteSVM, payer: &Keypair, max_withdraw: u64) {
+    let ix = build_initialize_ix(&payer.pubkey(), max_withdraw);
     send(svm, payer, &[ix], &[]).expect("initialize should succeed");
 }

--- a/programs/lamports-vault/tests/test_deposit.rs
+++ b/programs/lamports-vault/tests/test_deposit.rs
@@ -14,7 +14,7 @@ fn deposit_increases_vault_balance() {
     let user = Keypair::new();
     fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
 
-    initialize_vault(&mut svm, &user);
+    initialize_vault(&mut svm, &user, 100 * ONE_SOL);
 
     let (vault, _) = vault_pda(&user.pubkey());
     let vault_before = svm.get_balance(&vault).unwrap_or_default();
@@ -45,7 +45,7 @@ fn multiple_deposits_accumulate() {
     let user = Keypair::new();
     fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
 
-    initialize_vault(&mut svm, &user);
+    initialize_vault(&mut svm, &user, 100 * ONE_SOL);
 
     let (vault, _) = vault_pda(&user.pubkey());
     let vault_before = svm.get_balance(&vault).unwrap_or_default();
@@ -87,7 +87,7 @@ fn deposit_more_than_balance_fails() {
     let user = Keypair::new();
     fund(&mut svm, &user.pubkey(), 2 * ONE_SOL);
 
-    initialize_vault(&mut svm, &user);
+    initialize_vault(&mut svm, &user, 100 * ONE_SOL);
 
     // Try to deposit way more than the user has.
     let ix = build_deposit_ix(&user.pubkey(), 100 * ONE_SOL);
@@ -104,7 +104,7 @@ fn deposit_zero_lamports_succeeds_and_is_a_noop() {
     let user = Keypair::new();
     fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
 
-    initialize_vault(&mut svm, &user);
+    initialize_vault(&mut svm, &user, 100 * ONE_SOL);
 
     let (vault, _) = vault_pda(&user.pubkey());
     let vault_before = svm.get_balance(&vault).unwrap_or_default();

--- a/programs/lamports-vault/tests/test_initialize.rs
+++ b/programs/lamports-vault/tests/test_initialize.rs
@@ -17,7 +17,7 @@ fn initialize_creates_vault_state_and_funds_vault() {
     let (vault_state, expected_state_bump) = vault_state_pda(&payer.pubkey());
     let (vault, expected_vault_bump) = vault_pda(&payer.pubkey());
 
-    let ix = build_initialize_ix(&payer.pubkey());
+    let ix = build_initialize_ix(&payer.pubkey(), 100 * ONE_SOL);
     send(&mut svm, &payer, &[ix], &[]).expect("initialize should succeed");
 
     let state_account = svm
@@ -46,7 +46,7 @@ fn initialize_twice_for_same_payer_fails() {
     let payer = Keypair::new();
     fund(&mut svm, &payer.pubkey(), 10 * ONE_SOL);
 
-    let ix = build_initialize_ix(&payer.pubkey());
+    let ix = build_initialize_ix(&payer.pubkey(), 100 * ONE_SOL);
     send(&mut svm, &payer, &[ix.clone()], &[]).expect("first initialize should succeed");
 
     // Re-initializing with the same payer reuses the same PDAs and must fail
@@ -66,9 +66,9 @@ fn initialize_with_separate_payers_creates_independent_vaults() {
     fund(&mut svm, &alice.pubkey(), 10 * ONE_SOL);
     fund(&mut svm, &bob.pubkey(), 10 * ONE_SOL);
 
-    send(&mut svm, &alice, &[build_initialize_ix(&alice.pubkey())], &[])
+    send(&mut svm, &alice, &[build_initialize_ix(&alice.pubkey(), 100 * ONE_SOL)], &[])
         .expect("alice init should succeed");
-    send(&mut svm, &bob, &[build_initialize_ix(&bob.pubkey())], &[])
+    send(&mut svm, &bob, &[build_initialize_ix(&bob.pubkey(), 100 * ONE_SOL)], &[])
         .expect("bob init should succeed");
 
     let (alice_vault, _) = vault_pda(&alice.pubkey());

--- a/programs/lamports-vault/tests/test_withdraw.rs
+++ b/programs/lamports-vault/tests/test_withdraw.rs
@@ -15,7 +15,7 @@ fn withdraw_returns_lamports_to_user() {
     let user = Keypair::new();
     fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
 
-    initialize_vault(&mut svm, &user);
+    initialize_vault(&mut svm, &user, 100 * ONE_SOL);
 
     // Deposit first so the vault has withdrawable lamports.
     let deposit_amount = 3 * ONE_SOL;
@@ -65,7 +65,7 @@ fn withdraw_more_than_vault_holds_fails() {
     let user = Keypair::new();
     fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
 
-    initialize_vault(&mut svm, &user);
+    initialize_vault(&mut svm, &user, 1000 * ONE_SOL);
 
     // Try to withdraw far more than what the vault was seeded with at init.
     let res = send(
@@ -106,7 +106,7 @@ fn withdraw_with_wrong_user_fails() {
     fund(&mut svm, &owner.pubkey(), 10 * ONE_SOL);
     fund(&mut svm, &attacker.pubkey(), 10 * ONE_SOL);
 
-    initialize_vault(&mut svm, &owner);
+    initialize_vault(&mut svm, &owner, 100 * ONE_SOL);
     send(
         &mut svm,
         &owner,
@@ -130,3 +130,51 @@ fn withdraw_with_wrong_user_fails() {
         "an attacker without an initialized vault must not be able to withdraw"
     );
 }
+
+#[test]
+fn withdraw_under_the_limit_succeeds() {
+    let mut svm = setup_svm();
+    let user = Keypair::new();
+    fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
+
+    let max = 2 * ONE_SOL;
+    initialize_vault(&mut svm, &user, max);
+    send(&mut svm, &user, &[build_deposit_ix(&user.pubkey(), 5 * ONE_SOL)], &[])
+        .expect("deposit should succeed");
+
+    send(&mut svm, &user, &[build_withdraw_ix(&user.pubkey(), max - 1)], &[])
+        .expect("withdrawing under the limit should succeed");
+}
+
+#[test]
+fn withdraw_exactly_at_the_limit_succeeds() {
+    let mut svm = setup_svm();
+    let user = Keypair::new();
+    fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
+
+    let max = 2 * ONE_SOL;
+    initialize_vault(&mut svm, &user, max);
+    send(&mut svm, &user, &[build_deposit_ix(&user.pubkey(), 5 * ONE_SOL)], &[])
+        .expect("deposit should succeed");
+
+    // The boundary is inclusive: `amount == max_withdraw` must be allowed.
+    send(&mut svm, &user, &[build_withdraw_ix(&user.pubkey(), max)], &[])
+        .expect("withdrawing exactly the limit should succeed");
+}
+
+#[test]
+fn withdraw_over_the_limit_fails() {
+    let mut svm = setup_svm();
+    let user = Keypair::new();
+    fund(&mut svm, &user.pubkey(), 10 * ONE_SOL);
+
+    let max = 2 * ONE_SOL;
+    initialize_vault(&mut svm, &user, max);
+    // Deposit far more than we try to withdraw, so a rejection can ONLY be the cap.
+    send(&mut svm, &user, &[build_deposit_ix(&user.pubkey(), 5 * ONE_SOL)], &[])
+        .expect("deposit should succeed");
+
+    let res = send(&mut svm, &user, &[build_withdraw_ix(&user.pubkey(), max + 1)], &[]);
+    assert!(res.is_err(), "one lamport over the limit must be rejected");
+}
+


### PR DESCRIPTION
## What
Adds a per-transaction withdrawal limit to the lamports vault.

## Why
The vault currently allows draining the full balance in a single
withdraw. A per-transaction cap bounds the damage from a leaked key
or a buggy client.

## How
- `max_withdraw: u64` appended to `VaultState` (appended, not
  prepended, so the byte offsets `test_initialize` asserts on stay valid)
- set from a new `initialize` argument
- `withdraw` rejects `amount > max_withdraw` with `ExceedsMaxWithdraw`

## Testing
`anchor build && cargo test` — all existing tests pass, plus three new
ones covering under, exactly at, and one lamport over the cap.
